### PR TITLE
Bump System.Text.Json to 8.0.5 on master

### DIFF
--- a/NuGet/WebRTCme.Middleware.2.0.0.nuspec
+++ b/NuGet/WebRTCme.Middleware.2.0.0.nuspec
@@ -30,7 +30,7 @@
 		    <dependency id="Microsoft.Maui.Controls.Compatibility" version="8.0.6"  exclude="Build,Analyzers"/>
 		    <dependency id="CommunityToolkit.Maui" version="7.0.1"  exclude="Build,Analyzers"/>
     	  <dependency id="System.Net.WebSockets.Client" version="4.3.2"  exclude="Build,Analyzers"/>
-        <dependency id="System.Text.Json" version="8.0.1" exclude="Build,Analyzers" />
+        <dependency id="System.Text.Json" version="8.0.5" exclude="Build,Analyzers" />
         <dependency id="Refractored.MvvmHelpers" version="1.6.2" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Configuration.Binder" version="8.0.1" exclude="Build,Analyzers" />
 	      <dependency id="System.Threading.Channels" version="8.0.0" exclude="Build,Analyzers"/>
@@ -54,7 +54,7 @@
 		    <dependency id="Microsoft.Maui.Controls.Compatibility" version="8.0.6"  exclude="Build,Analyzers"/>
 		    <dependency id="CommunityToolkit.Maui" version="7.0.1"  exclude="Build,Analyzers"/>
     	  <dependency id="System.Net.WebSockets.Client" version="4.3.2"  exclude="Build,Analyzers"/>
-        <dependency id="System.Text.Json" version="8.0.1" exclude="Build,Analyzers" />
+        <dependency id="System.Text.Json" version="8.0.5" exclude="Build,Analyzers" />
         <dependency id="Refractored.MvvmHelpers" version="1.6.2" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Configuration.Binder" version="8.0.1" exclude="Build,Analyzers" />
 	      <dependency id="System.Threading.Channels" version="8.0.0" exclude="Build,Analyzers"/>
@@ -77,7 +77,7 @@
 		    <dependency id="Microsoft.AspNetCore.Components" version="8.0.1" exclude="Build,Analyzers" />
 		    <dependency id="Microsoft.AspNetCore.Components.Web" version="8.0.1" exclude="Build,Analyzers" />
     	  <dependency id="System.Net.WebSockets.Client" version="4.3.2"  exclude="Build,Analyzers"/>
-        <dependency id="System.Text.Json" version="8.0.1" exclude="Build,Analyzers" />
+        <dependency id="System.Text.Json" version="8.0.5" exclude="Build,Analyzers" />
         <dependency id="Refractored.MvvmHelpers" version="1.6.2" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Configuration.Binder" version="8.0.1" exclude="Build,Analyzers" />
         <dependency id="BlazorDialog" version="2.3.0"  exclude="Build,Analyzers"/>

--- a/WebRTCme.Api/WebRTCme.Api.csproj
+++ b/WebRTCme.Api/WebRTCme.Api.csproj
@@ -24,7 +24,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
-		<PackageReference Include="System.Text.Json" Version="8.0.1" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/WebRTCme.Middleware/WebRTCme.Middleware/WebRTCme.Middleware.csproj
+++ b/WebRTCme.Middleware/WebRTCme.Middleware/WebRTCme.Middleware.csproj
@@ -31,7 +31,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
-      <PackageReference Include="System.Text.Json" Version="8.0.1" />
+      <PackageReference Include="System.Text.Json" Version="8.0.5" />
 	  <PackageReference Include="Refractored.MvvmHelpers" Version="1.6.2" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
 	</ItemGroup>


### PR DESCRIPTION
Clears the six open high-severity Dependabot alerts.

They are all the same two `System.Text.Json` advisories against three manifests on `master`, which still pins `8.0.1`:

| Manifest | Was | Now |
|---|---|---|
| `WebRTCme.Api/WebRTCme.Api.csproj` | 8.0.1 | 8.0.5 |
| `WebRTCme.Middleware/WebRTCme.Middleware/WebRTCme.Middleware.csproj` | 8.0.1 | 8.0.5 |
| `NuGet/WebRTCme.Middleware.2.0.0.nuspec` (3 dependency groups) | 8.0.1 | 8.0.5 |

`8.0.5` is the first patched version for both advisories (vulnerable ranges `>= 7.0.0, < 8.0.4` and `>= 8.0.0, <= 8.0.4`) and stays inside the 8.x band that `master` targets, so it is a servicing-level bump only.

`feature/dotnet10_support` needs no equivalent change: its csprojs moved to `10.0.9` with the net10.0 migration, and its nuspec already declares `8.0.5`. Dependabot keeps reporting because it only scans the default branch.

Not built locally — this machine has the 10.0.400 SDK and no .NET 8 targeting pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)